### PR TITLE
v0.7.5 and beyond

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ Installs [Shortcat](http://shortcatapp.com/).
 include shortcat
 ```
 
+You can specify a version:
+
+``` puppet
+class { 'shortcat': version => 'v1.0.0' }
+```
+
+...or in Hiera...
+
+``` yaml
+shortcat::version: v1.0.0
+```
+
 ## Required Puppet Modules
 
 * `boxen`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #
 #   include shortcat
 class shortcat (
-  $version = 'v0.7.4'
+  $version = 'v0.7.5'
 ) {
   package { 'Shortcat':
     source   => "https://files.shortcatapp.com/${version}/Shortcat.zip",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,11 @@
 # Usage:
 #
 #   include shortcat
-class shortcat {
+class shortcat (
+  $version = 'v0.7.4'
+) {
   package { 'Shortcat':
-    source   => 'https://files.shortcatapp.com/v0.6.1/Shortcat.zip',
+    source   => "https://files.shortcatapp.com/${version}/Shortcat.zip",
     provider => 'compressed_app'
   }
 }

--- a/spec/classes/shortcat_spec.rb
+++ b/spec/classes/shortcat_spec.rb
@@ -1,10 +1,20 @@
 require 'spec_helper'
 
 describe 'shortcat' do
-  it do
-    should contain_package('Shortcat').with({
-      :source   => 'https://files.shortcatapp.com/v0.6.1/Shortcat.zip',
-      :provider => 'compressed_app'
-    })
+  shared_examples 'it installs shortcat' do
+    it { should contain_class('shortcat') }
+    it { should contain_package('Shortcat').with_provider('compressed_app') }
+  end
+
+  context 'with no parameters' do
+    it_behaves_like 'it installs shortcat'
+    it { should contain_package('Shortcat').with_source('https://files.shortcatapp.com/v0.7.4/Shortcat.zip') }
+  end
+
+  context 'with a version' do
+    let(:params) { { :version => 'v1.0.0' } }
+
+    it_behaves_like 'it installs shortcat'
+    it { should contain_package('Shortcat').with_source('https://files.shortcatapp.com/v1.0.0/Shortcat.zip') }
   end
 end

--- a/spec/classes/shortcat_spec.rb
+++ b/spec/classes/shortcat_spec.rb
@@ -8,7 +8,7 @@ describe 'shortcat' do
 
   context 'with no parameters' do
     it_behaves_like 'it installs shortcat'
-    it { should contain_package('Shortcat').with_source('https://files.shortcatapp.com/v0.7.4/Shortcat.zip') }
+    it { should contain_package('Shortcat').with_source('https://files.shortcatapp.com/v0.7.5/Shortcat.zip') }
   end
 
   context 'with a version' do


### PR DESCRIPTION
Currently, Shortcat has to update as soon as it's started.

This change updates the URL to the latest version and allows users or organisations to specify their own version without updating the Puppet manifest.